### PR TITLE
add rando_get_unconverted_item_id and rando_get_last_location + separate stray fairies

### DIFF
--- a/apcpp-glue.cpp
+++ b/apcpp-glue.cpp
@@ -251,7 +251,7 @@ extern "C"
             _return(ctx, (u32) item);
             return;
         }
-
+        
         _return(ctx, 0);
     }
 
@@ -305,7 +305,24 @@ extern "C"
             switch (item & 0xFF0000)
             {
                 case 0x010000:
-                    _return(ctx, (u32) GI_B2);
+                    switch (item & 0xFF)
+                    {
+                        case 0x7F:
+                            _return(ctx, (u32) GI_B2);
+                            return;
+                        case 0x00:
+                            _return(ctx, (u32) GI_46);
+                            return;
+                        case 0x01:
+                            _return(ctx, (u32) GI_47);
+                            return;
+                        case 0x02:
+                            _return(ctx, (u32) GI_48);
+                            return;
+                        case 0x03:
+                            _return(ctx, (u32) GI_49);
+                            return;
+                    }
                     return;
                 case 0x020000:
                     switch (item & 0xFF)


### PR DESCRIPTION
Adds new functions to retrieve the last/current item grabbed. Currently used for changing text based on the real version of the current item.

Also separates stray fairies into different items for future changes. Planning on expanding this to keys too so they can be recolored per dungeon.