### PR TITLE
fix sanity options

### DIFF
--- a/apcpp-glue.cpp
+++ b/apcpp-glue.cpp
@@ -86,6 +86,61 @@ u32 hasItem(u64 itemId)
     return count;
 }
 
+int64_t fixLocation(u32 arg)
+{
+    if ((arg & 0xFF0000) == 0x090000 && AP_GetSlotDataInt("shopsanity") == 1)
+    {
+        u32 shopItem = arg & 0xFFFF;
+        switch (shopItem)
+        {
+            case SI_NUTS_2:
+                shopItem = SI_NUTS_1;
+                break;
+            case SI_STICK_2:
+                shopItem = SI_STICK_1;
+                break;
+            case SI_ARROWS_LARGE_2:
+                shopItem = SI_ARROWS_LARGE_1;
+                break;
+            case SI_ARROWS_MEDIUM_2:
+                shopItem = SI_ARROWS_MEDIUM_1;
+                break;
+            case SI_FAIRY_2:
+                shopItem = SI_FAIRY_1;
+                break;
+            case SI_POTION_GREEN_3:
+                shopItem = SI_POTION_GREEN_2;
+                break;
+            case SI_SHIELD_HERO_2:
+                shopItem = SI_SHIELD_HERO_1;
+                break;
+            case SI_POTION_RED_3:
+                shopItem = SI_POTION_RED_2;
+                break;
+
+            case SI_POTION_RED_6:
+                shopItem = SI_POTION_RED_5;
+                break;
+            case SI_ARROWS_SMALL_3:
+                shopItem = SI_ARROWS_SMALL_2;
+                break;
+            case SI_BOMB_3:
+                shopItem = SI_BOMB_2;
+                break;
+
+            // case SI_BOTTLE:
+            // case SI_SWORD_GREAT_FAIRY:
+            // case SI_SWORD_KOKIRI:
+            // case SI_SWORD_RAZOR:
+            // case SI_SWORD_GILDED:
+            //     shopItem = SI_SWORD_KOKIRI;
+            //     break;
+        }
+        return 0x090000 | shopItem;
+    }
+    return arg;
+}
+
 extern "C"
 {
     DLLEXPORT u32 recomp_api_version = 1;
@@ -169,6 +224,20 @@ extern "C"
         _return(ctx, AP_GetSlotDataInt("skullsanity") != 2);
     }
     
+    DLLEXPORT void rando_shopsanity_enabled(uint8_t* rdram, recomp_context* ctx)
+    {
+        _return(ctx, AP_GetSlotDataInt("shopsanity") != 0);
+    }
+
+    DLLEXPORT void rando_scrubs_enabled(uint8_t* rdram, recomp_context* ctx)
+    {
+        _return(ctx, AP_GetSlotDataInt("scrubsanity") == 1);
+    }
+
+    DLLEXPORT void rando_cows_enabled(uint8_t* rdram, recomp_context* ctx)
+    {
+        _return(ctx, AP_GetSlotDataInt("cowsanity") == 1);
+    }
     
     DLLEXPORT void rando_damage_multiplier(uint8_t* rdram, recomp_context* ctx)
     {
@@ -256,7 +325,7 @@ extern "C"
     DLLEXPORT void rando_get_location_type(uint8_t* rdram, recomp_context* ctx)
     {
         u32 arg = _arg<0, u32>(rdram, ctx);
-        int64_t location = 0x3469420000000 | arg;
+        int64_t location = 0x3469420000000 | fixLocation(arg);
         _return(ctx, (int) AP_GetLocationItemType(location));
     }
     
@@ -270,7 +339,7 @@ extern "C"
             return;
         }
         
-        int64_t location = 0x3469420000000 | arg;
+        int64_t location = 0x3469420000000 | fixLocation(arg);
         
         if (AP_GetLocationHasLocalItem(location))
         {
@@ -429,14 +498,14 @@ extern "C"
     DLLEXPORT void rando_has_item(uint8_t* rdram, recomp_context* ctx)
     {
         u32 arg = _arg<0, u32>(rdram, ctx);
-        int64_t location_id = ((int64_t) (((int64_t) 0x3469420000000) | ((int64_t) arg)));
+        int64_t location_id = ((int64_t) (((int64_t) 0x3469420000000) | ((int64_t) fixLocation(arg))));
         _return(ctx, hasItem(location_id));
     }
     
     DLLEXPORT void rando_send_location(uint8_t* rdram, recomp_context* ctx)
     {
         u32 arg = _arg<0, u32>(rdram, ctx);
-        int64_t location_id = ((int64_t) (((int64_t) 0x3469420000000) | ((int64_t) arg)));
+        int64_t location_id = ((int64_t) (((int64_t) 0x3469420000000) | ((int64_t) fixLocation(arg))));
         if (!AP_GetLocationIsChecked(location_id))
         {
             AP_SendItem(location_id);
@@ -446,7 +515,7 @@ extern "C"
     DLLEXPORT void rando_location_is_checked(uint8_t* rdram, recomp_context* ctx)
     {
         u32 arg = _arg<0, u32>(rdram, ctx);
-        int64_t location_id = ((int64_t) (((int64_t) 0x3469420000000) | ((int64_t) arg)));
+        int64_t location_id = ((int64_t) (((int64_t) 0x3469420000000) | ((int64_t) fixLocation(arg))));
         _return(ctx, AP_GetLocationIsChecked(location_id));
     }
     

--- a/apcpp-glue.cpp
+++ b/apcpp-glue.cpp
@@ -259,6 +259,10 @@ extern "C"
                             int64_t location_id = 0x3469420090000 | i;
                             AP_RemoveQueuedLocationScout(location_id);
                         }
+
+                        AP_RemoveQueuedLocationScout(0x3469420026392);
+                        AP_RemoveQueuedLocationScout(0x3469420090000 | GI_CHATEAU);
+                        AP_RemoveQueuedLocationScout(0x3469420006792);
                     }
                 }
                 

--- a/apcpp-glue.cpp
+++ b/apcpp-glue.cpp
@@ -139,10 +139,10 @@ int64_t fixLocation(u32 arg)
         return 0x090000 | shopItem;
     }
 
-    if (arg == 0x05481E) {
+    if (arg == 0x05481E && AP_GetSlotDataInt("shopsanity") != 2) {
         return 0x054D1E;
     }
-    
+
     return arg;
 }
 
@@ -201,12 +201,65 @@ extern "C"
                         int64_t location_id = 0x3469420062700 | i;
                         AP_RemoveQueuedLocationScout(location_id);
                     }
+                    for (int i = 0x01; i <= 0x1E; ++i)
+                    {                        
+                        int64_t location_id = 0x3469420062800 | i;
+                        AP_RemoveQueuedLocationScout(location_id);
+                    }
                 }
                 
                 for (int64_t i = AP_GetSlotDataInt("starting_heart_locations"); i < 8; ++i)
                 {
                     int64_t location_id = 0x34694200D0000 | i;
                     AP_RemoveQueuedLocationScout(location_id);
+                }
+
+                if (AP_GetSlotDataInt("cowsanity") == 0)
+                {
+                    for (int i = 0x10; i <= 0x17; ++i)
+                    {                        
+                        int64_t location_id = 0x3469420BEEF00 | i;
+                        AP_RemoveQueuedLocationScout(location_id);
+                    }
+                }
+
+                if (AP_GetSlotDataInt("scrubsanity") == 0)
+                {
+                    AP_RemoveQueuedLocationScout(0x3469420090100 | GI_MAGIC_BEANS);
+                    AP_RemoveQueuedLocationScout(0x3469420090100 | GI_BOMB_BAG_40);
+                    AP_RemoveQueuedLocationScout(0x3469420090100 | GI_POTION_GREEN);
+                    AP_RemoveQueuedLocationScout(0x3469420090100 | GI_POTION_BLUE);
+                }
+
+                if (AP_GetSlotDataInt("shopsanity") != 2)
+                {
+                    if (AP_GetSlotDataInt("shopsanity") == 1)
+                    {
+                        for (int i = SI_FAIRY_2; i <= SI_POTION_RED_3; ++i)
+                        {                        
+                            int64_t location_id = 0x3469420090000 | i;
+                            AP_RemoveQueuedLocationScout(location_id);
+                        }
+
+                        AP_RemoveQueuedLocationScout(0x3469420090000 | SI_BOMB_3);
+                        AP_RemoveQueuedLocationScout(0x3469420090000 | SI_ARROWS_SMALL_3);
+                        AP_RemoveQueuedLocationScout(0x3469420090000 | SI_POTION_RED_6);
+                        
+                        AP_RemoveQueuedLocationScout(0x346942005481E);
+                    }
+                    else
+                    {
+                        for (int i = SI_POTION_RED_1; i <= SI_POTION_RED_6; ++i)
+                        {
+                            if (i == SI_BOMB_BAG_20_1 || i == SI_BOMB_BAG_40)
+                            {
+                                continue;
+                            }
+
+                            int64_t location_id = 0x3469420090000 | i;
+                            AP_RemoveQueuedLocationScout(location_id);
+                        }
+                    }
                 }
                 
                 AP_SendQueuedLocationScouts(0);

--- a/apcpp-glue.cpp
+++ b/apcpp-glue.cpp
@@ -302,9 +302,9 @@ extern "C"
         _return(ctx, AP_GetSlotDataInt("permanent_chateau_romani") == 1);
     }
     
-    DLLEXPORT void rando_get_reset_with_inverted_time_enabled(uint8_t* rdram, recomp_context* ctx)
+    DLLEXPORT void rando_get_start_with_inverted_time_enabled(uint8_t* rdram, recomp_context* ctx)
     {
-        _return(ctx, AP_GetSlotDataInt("reset_with_inverted_time") == 1);
+        _return(ctx, AP_GetSlotDataInt("start_with_inverted_time") == 1);
     }
     
     DLLEXPORT void rando_get_receive_filled_wallets_enabled(uint8_t* rdram, recomp_context* ctx)

--- a/apcpp-glue.cpp
+++ b/apcpp-glue.cpp
@@ -138,6 +138,11 @@ int64_t fixLocation(u32 arg)
         }
         return 0x090000 | shopItem;
     }
+
+    if (arg == 0x05481E) {
+        return 0x054D1E;
+    }
+    
     return arg;
 }
 

--- a/apcpp-glue.cpp
+++ b/apcpp-glue.cpp
@@ -281,7 +281,24 @@ extern "C"
             switch (item & 0xFF0000)
             {
                 case 0x010000:
-                    _return(ctx, (u32) GI_B2);
+                    switch (item & 0xFF)
+                    {
+                        case 0x7F:
+                            _return(ctx, (u32) GI_B2);
+                            return;
+                        case 0x00:
+                            _return(ctx, (u32) GI_46);
+                            return;
+                        case 0x01:
+                            _return(ctx, (u32) GI_47);
+                            return;
+                        case 0x02:
+                            _return(ctx, (u32) GI_48);
+                            return;
+                        case 0x03:
+                            _return(ctx, (u32) GI_49);
+                            return;
+                    }
                     return;
                 case 0x020000:
                     switch (item & 0xFF)

--- a/apcpp-glue.cpp
+++ b/apcpp-glue.cpp
@@ -169,6 +169,35 @@ extern "C"
         _return(ctx, AP_GetSlotDataInt("skullsanity") != 2);
     }
     
+    
+    DLLEXPORT void rando_damage_multiplier(uint8_t* rdram, recomp_context* ctx)
+    {
+        switch (AP_GetSlotDataInt("damage_multiplier"))
+        {
+            case 0:
+                _return(ctx, (u32) 0);
+                return;
+            case 1:
+                _return(ctx, (u32) 1);
+                return;
+            case 2:
+                _return(ctx, (u32) 2);
+                return;
+            case 3:
+                _return(ctx, (u32) 4);
+                return;
+            case 4:
+                _return(ctx, (u32) 0xF);
+                return;
+        }
+        return;
+    }
+    
+    DLLEXPORT void rando_death_behavior(uint8_t* rdram, recomp_context* ctx)
+    {
+        _return(ctx, (u32) AP_GetSlotDataInt("death_behavior"));
+    }
+
     DLLEXPORT void rando_get_death_link_pending(uint8_t* rdram, recomp_context* ctx)
     {
         _return(ctx, AP_DeathLinkPending());

--- a/apcpp-glue.h
+++ b/apcpp-glue.h
@@ -423,6 +423,53 @@ typedef enum GetItemId {
     /* 0xBA */ GI_MAX
 } GetItemId;
 
+typedef enum EnGirlAShopItemId {
+    /* 0x00 */ SI_POTION_RED_1,
+    /* 0x01 */ SI_POTION_GREEN_1,
+    /* 0x02 */ SI_POTION_BLUE,
+    /* 0x03 */ SI_FAIRY_1,
+    /* 0x04 */ SI_ARROWS_LARGE_1,
+    /* 0x05 */ SI_POTION_GREEN_2,
+    /* 0x06 */ SI_SHIELD_HERO_1,
+    /* 0x07 */ SI_STICK_1,
+    /* 0x08 */ SI_ARROWS_MEDIUM_1,
+    /* 0x09 */ SI_NUTS_1,
+    /* 0x0A */ SI_POTION_RED_2,
+    /* 0x0B */ SI_FAIRY_2,
+    /* 0x0C */ SI_ARROWS_MEDIUM_2,
+    /* 0x0D */ SI_ARROWS_LARGE_2,
+    /* 0x0E */ SI_POTION_GREEN_3,
+    /* 0x0F */ SI_NUTS_2,
+    /* 0x10 */ SI_STICK_2,
+    /* 0x11 */ SI_SHIELD_HERO_2,
+    /* 0x12 */ SI_POTION_RED_3,
+    /* 0x13 */ SI_MASK_ALL_NIGHT,
+    /* 0x14 */ SI_BOMB_BAG_20_1,
+    /* 0x15 */ SI_BOMB_BAG_30_1,
+    /* 0x16 */ SI_BOMB_BAG_40,
+    /* 0x17 */ SI_BOMB_BAG_20_2,
+    /* 0x18 */ SI_BOMB_BAG_30_2,
+    /* 0x19 */ SI_BOMBCHU,
+    /* 0x1A */ SI_BOMB_1,
+    /* 0x1B */ SI_SHIELD_HERO_3,
+    /* 0x1C */ SI_ARROWS_SMALL_1,
+    /* 0x1D */ SI_POTION_RED_4,
+    /* 0x1E */ SI_BOMB_2,
+    /* 0x1F */ SI_ARROWS_SMALL_2,
+    /* 0x20 */ SI_POTION_RED_5,
+    /* 0x21 */ SI_BOMB_3,
+    /* 0x22 */ SI_ARROWS_SMALL_3,
+    /* 0x23 */ SI_POTION_RED_6,
+    /* 0x24 */ SI_BOTTLE,
+    /* 0x25 */ SI_SWORD_GREAT_FAIRY,
+    /* 0x26 */ SI_SWORD_KOKIRI,
+    /* 0x27 */ SI_SWORD_RAZOR,
+    /* 0x28 */ SI_SWORD_GILDED,
+    /* 0x29 */ SI_SHIELD_HERO_4,
+    /* 0x2A */ SI_SHIELD_MIRROR,
+    /* 0x2B */ SI_MAX
+} EnGirlAShopItemId;
+
 typedef uint64_t gpr;
 
 typedef union {


### PR DESCRIPTION
Removes all new sanity options (including Ocean Skulltulas) from the location scout based on those options.